### PR TITLE
Only load addressbook if not already in memory

### DIFF
--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -197,6 +197,12 @@ async def getErnings(hass, headersData, allData, deviceID):
 
 async def getAddresbook(hass, headersData, allData, deviceID):
 
+    # Don't bother pulling the address book again if we've already
+    # got data cached in memory. It doesn't change enough to be
+    # worth hitting the API each time.
+    if allData.get('addressbook', []):
+        return
+
     restAddressBook = RestData(hass, METHOD_GET, _ENDPOINT_ADDRESSBOOK +
                                deviceID, None, headersData, None, None, DEFAULT_VERIFY_SSL)
     await restAddressBook.async_update()


### PR DESCRIPTION
If the addressbook data block is already populated, dont reload it and just return.

Signed-off-by: Toby Jackson <toby@warmfusion.co.uk>

See https://github.com/macxq/foxess-ha/issues/41