### PR TITLE
Add new multi-inverter wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sensor:
 - `foxesscloud_inverter_id` in UUID that can be found on the foxesscloud in the url path on the `Inverter Details` page.
 ⚠️  Please make sure that this is exact value from inverter details page address between = and & character:
 ![Screenshot 2021-11-08 at 08 42 05](https://user-images.githubusercontent.com/2965092/140761535-edb12226-b2b8-4f2b-87ce-11b67476a9e2.png)
-- if you have more than one FoxESS device in your installation you can leverage optional `name` field in you config, if you want se some example check out [here](https://github.com/macxq/foxess-ha/issues/11#issuecomment-990228995)
+- Multi-inverter support - if you have more than one FoxESS device in your installation, you can leverage the optional `name` field in you config, if you want see an example check out [here](https://github.com/macxq/foxess-ha/wiki/Multi-Inverter-Support)
 
 
 


### PR DESCRIPTION
Added a link to the new multi-inverter support wiki page with an example config and tweaked some typos.