### PR TITLE
Update sensor.py - Avoiding Negative Values in Energy Charts of HA for Solar Production

### DIFF
--- a/custom_components/foxess/manifest.json
+++ b/custom_components/foxess/manifest.json
@@ -1,11 +1,11 @@
 {
-  "domain": "foxess",
-  "name": "HA & FoxESSCloud integration",
-  "documentation": "https://github.com/macxq/foxess-ha",
+  "codeowners": [r-amado],
   "dependencies": ["rest"],
-  "codeowners": [],
-  "requirements": ["random_user_agent"],
+  "documentation": "https://github.com/macxq/foxess-ha",
+  "domain": "foxess",
   "iot_class": "local_polling",
-  "version": "v0.4",
   "issue_tracker":"https://github.com/macxq/foxess-ha/issues"
+  "name": "HA & FoxESSCloud integration",
+  "requirements": ["random_user_agent"],
+  "version": "v0.4",  
 }

--- a/custom_components/foxess/manifest.json
+++ b/custom_components/foxess/manifest.json
@@ -6,6 +6,6 @@
   "codeowners": [],
   "requirements": ["random_user_agent"],
   "iot_class": "local_polling",
-  "version": "v0.3",
+  "version": "v0.4",
   "issue_tracker":"https://github.com/macxq/foxess-ha/issues"
 }

--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -848,11 +848,10 @@ class FoxESSEnergySolar(CoordinatorEntity, SensorEntity):
                 self.coordinator.data["report"]["gridConsumption"])
             discharge = float(
                 self.coordinator.data["report"]["dischargeEnergyToTal"])
-
-            #round the result
-            return round((loads + charge + feedIn - gridConsumption - discharge),3)
-            #original
-            #return loads + charge + feedIn - gridConsumption - discharge
+            energysolar = round((loads + charge + feedIn - gridConsumption - discharge),3)
+            if energysolar<0:
+                energysolar=0
+            return round(energysolar,3)
         return None
 
 


### PR DESCRIPTION
 Avoid the negative values that are presented each morning when FOX resets the counters? All charts of energy in HA shows a negative value as the first value, equals to the amount of energy solar produced in the day before.