### PR TITLE
Token invalid 41809 and Timeout 41808 handling improved to re-connect

### DIFF
--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -272,18 +272,14 @@ async def getAddresbook(hass, headersData, allData, deviceID,username, hashedPas
         return False
     else:
         response = json.loads(restAddressBook.data)
-        if response["errno"] is not None and response["errno"] == 41809:
-                if tokenRefreshRetrys > 2:
-                    raise UpdateFailed(f"Unable to refresh token in {tokenRefreshRetrys} retries")
+        if response["errno"] is not None and (response["errno"] == 41808 or response["errno"] == 41808):
                 global token
-                _LOGGER.debug(f"Token has expierd, re-authenticating {tokenRefreshRetrys}")
-                token = await authAndgetToken(hass, username, hashedPassword)
-                getErnings(hass, headersData, allData, deviceID, username, hashedPassword,tokenRefreshRetrys+1)
+                _LOGGER.debug(f"Token has expired, re-authenticating {tokenRefreshRetrys}")
+                token = None
         else:
             _LOGGER.debug(
                 "FoxESS Addressbook data fetched correcly "+restAddressBook.data)
             allData['addressbook'] = response
-
 
 async def getReport(hass, headersData, allData, deviceID):
     now = datetime.now()

--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -272,7 +272,7 @@ async def getAddresbook(hass, headersData, allData, deviceID,username, hashedPas
         return False
     else:
         response = json.loads(restAddressBook.data)
-        if response["errno"] is not None and (response["errno"] == 41808 or response["errno"] == 41808):
+        if response["errno"] is not None and (response["errno"] == 41809 or response["errno"] == 41808):
                 global token
                 _LOGGER.debug(f"Token has expired, re-authenticating {tokenRefreshRetrys}")
                 token = None


### PR DESCRIPTION
The original code for getAddressbook had a check for token invalid, but the error handling code had been orphaned and did not work, it also didn't catch the case of token expiring (41808).

This PR changes the default error handling to log the error message, reset the Token to None which forces the main loop to attempt to re-authenticate.

System logs now when the token expires.

2023-03-30 20:03:25.264 DEBUG (MainThread) [custom_components.foxess.sensor] Updating data from https://www.foxesscloud.com/
2023-03-30 20:03:25.607 DEBUG (MainThread) [custom_components.foxess.sensor] Token has expired, re-authenticating 0
2023-03-30 20:03:25.608 ERROR (MainThread) [custom_components.foxess.sensor] Unexpected error fetching FoxESS data: 'addressbook'
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 239, in _async_refresh
self.data = await self._async_update_data()
File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 195, in _async_update_data
return await self.update_method()
File "/config/custom_components/foxess/sensor.py", line 143, in async_update_data
if int(allData["addressbook"]["result"]["status"]) == 1 or int(allData["addressbook"]["result"]["status"]) == 2:
KeyError: 'addressbook'
2023-03-30 20:03:25.619 DEBUG (MainThread) [custom_components.foxess.sensor] Finished fetching FoxESS data in 0.355 seconds (success: False)
2023-03-30 20:33:25.265 DEBUG (MainThread) [custom_components.foxess.sensor] Updating data from https://www.foxesscloud.com/
2023-03-30 20:33:25.265 DEBUG (MainThread) [custom_components.foxess.sensor] Token is empty, authenticating for the firts time
2023-03-30 20:33:25.440 DEBUG (MainThread) [custom_components.foxess.sensor] Login succesfull{"errno":0,"result":