### PR TITLE
Small update to allow data to be fetched when the plant is off-line and correctly updates inverter status

### DIFF
--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -141,7 +141,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         await getAddresbook(hass, headersData, allData, deviceID, username, hashedPassword,0)
 
 
-        if int(allData["addressbook"]["result"]["status"]) == 1 or int(allData["addressbook"]["result"]["status"]) == 2:
+        if int(allData["addressbook"]["result"]["status"]) == 1 or int(allData["addressbook"]["result"]["status"]) == 2 or int(allData["addressbook"]["result"]["status"]) == 3:
             allData["online"] = True
             await getRaw(hass, headersData, allData, deviceID)
             await getReport(hass, headersData, allData, deviceID)
@@ -1442,7 +1442,10 @@ class FoxESSInverter(CoordinatorEntity, SensorEntity):
         if int(self.coordinator.data["addressbook"]["result"]["status"]) == 1:
             return "on-line"
         else:
-            return "off-line"
+            if int(self.coordinator.data["addressbook"]["result"]["status"]) == 2:
+                return "in-alarm"
+            else:
+                return "off-line"
 
     @property
     def extra_state_attributes(self):


### PR DESCRIPTION
Just a small change following on from some issues reported yesterday (#152) and reports of sensors becoming unavailable when the plant goes off-line.

The integration currently checks for status =1 (on-line) and status =2 (alarm) but abandons the update if the plant is status =3 (off-line), this change continues to process the data if the plant is off-line but the cloud is ok.

It improves the inverter status sensor (sensor.foxess_inverter) which now shows the 3 distinct states (off-line, on-line, in-alarm)

Status 1 - on-line:
![image](https://user-images.githubusercontent.com/113460294/232025988-7458d7ba-16c0-4e78-ae75-2b6235739cb3.png)

Status 2 - in-alarm:
![image](https://user-images.githubusercontent.com/113460294/232026182-47e883bc-adca-4782-97dd-794715110524.png)

Status 3 - off-line:
![offline](https://user-images.githubusercontent.com/113460294/232025700-f86182fc-e981-4033-8ac8-95b7e36a2fed.jpg)

