### PR TITLE
Switch to TOTAL_INCREASING for Solar Energy sensor

### DIFF
--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -1466,7 +1466,7 @@ class FoxESSInverter(CoordinatorEntity, SensorEntity):
 
 class FoxESSEnergySolar(CoordinatorEntity, SensorEntity):
 
-    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL
+    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL_INCREASING
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
 


### PR DESCRIPTION
Total resets daily, so this is needed to avoid negative spikes in the energy dashboard.

Fixes #123