### PR TITLE
correct off-line handling for startup and standby use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ This sounds like a large number of calls, but bear in mind that multiple API cal
 
 The integration paces the number of API calls that are made, with the following frequency -
 
-- Site status and plant details - every 30 minutes
+- Site status and plant details - every 15 minutes
 - Real time variables - every 5 minutes
 - Cumulative total reports (generation, feedin, gridConsumption, BatterychargeTotal, Batterydischargetotal, home load) - every 15 minutes
 - Daily Generation report (Daily Energy Generated - 'total yield') - every 30 minutes
 - Battery minSoC settings - every 30 minutes
 
-The integration is using approximately 24 API calls an hour (576 a day and well within the 1,440), there are some outstanding requests on FoxESS R&D that could reduce this further and hopefully in future allow faster updates.
+The integration is using approximately 24 API calls an hour (576 a day and well within the 1,440).
 
 If you have multiple inverters in your account, you will receive 1,440 calls per inverter, so for 2 inverters you will have 2,880 api calls.
 


### PR DESCRIPTION
This release corrects the bug introduced in v0.38 which sees the entities become unavailable should an inverter go into standby or if it is 'off-line' at startup.

When an inverter goes off-line (i.e. in standby, powered down) the integration will mark the entities as unavailable and stop polling for entity updates. The plant status will be checked every 5 minutes and once it returns 'on-line' the integration will begin polling for variable updates and update all entities.

Site / Plant status when running in normal 'on-line' mode is now checked every 15 minutes (reduced from 30 minutes in previous releases), when off-line it is checked every 5 minutes.