### PR TITLE
H3 Pro - added support for PV5 and PV6 sensors and dual battery SoC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ Solar  |  kWh
 Load |  kWh 
 Bat Charge  |  kWh 
 Bat Discharge  |  kWh  
-Bat SoC | %
+Bat SoC | % (for single battery systems)
+Bat SoC1 | % (for dual battery systems)
+Bat SoC2 | % (for dual battery systems)
 Bat Temp | °C 
 Ambient Temp | °C
 Boost Temp | °C

--- a/custom_components/foxess/manifest.json
+++ b/custom_components/foxess/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "foxess",
   "name": "HA & FoxESSCloud integration",
-  "codeowners": ["@macxq","@r-amado","fozzieuk"],
+  "codeowners": ["@macxq","@r-amado","@fozzieuk"],
   "dependencies": ["rest"],
   "documentation": "https://github.com/macxq/foxess-ha",
   "iot_class": "local_polling",

--- a/custom_components/foxess/manifest.json
+++ b/custom_components/foxess/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "foxess",
   "name": "HA & FoxESSCloud integration",
-  "codeowners": ["@macxq","@r-amado"],
+  "codeowners": ["@macxq","@r-amado","fozzieuk"],
   "dependencies": ["rest"],
   "documentation": "https://github.com/macxq/foxess-ha",
   "iot_class": "local_polling",

--- a/info.md
+++ b/info.md
@@ -3,10 +3,6 @@
 👍 You already have the latest released version installed. 
 {% endif %}
 
-{% if installed and version_installed != selected_tag %}
- 🤓 Changes from version {{ version_installed }}
-{% endif %}
-
 <h2 align="center">
    <a href="https://www.fox-ess.com">FoxESS</a> and<a href="https://www.home-assistant.io"> Home Assistant</a> integration  🏡 ☀
    </br></br>
@@ -24,27 +20,49 @@ Use hacs.io to manage the installation and update process. Right now this integr
 
 ## ⌨️ Manual installation 
 
-Copy content of `custom_components` folder into your HA `/config/custom_components` folder
+Create the folder called `foxess` in `/homeassistant/custom_components`
+
+Copy the content of this integrations `custom_components/foxess` folder into your HA `/homeassistant/custom_components/foxess` folder
 
 
 
 ## 💾 Configuration
 
-Edit your home-assistan `/configuration.yaml`  and add:
+Edit your home-assistant `/configuration.yaml`  and add:
 
 ```yaml
 sensor:
   - platform: foxess
-    username: foxesscloud_username
-    password: foxesscloud_password
-    deviceID: foxesscloud_inverter_id
+    deviceID: enter_your_inverter_id
+    deviceSN: enter_your_inverter_serial_number
+    apiKey: enter_your_personal_api_key
 ```
 
 #### Auxiliary notes:
-- `foxesscloud_inverter_id` in UUID that can be found on the foxesscloud in the url path on the `Inverter Details` page.
+- `username & password` are no longer required for this integration, it uses your_personal_api_key instead.
+
+- `your_inverter_serial_number` is the serial number of the inverter this integration will be gathering data from, you can see the deviceSN by logging into the Foxesscloud.com website, in the left hand menu click on 'Device', then 'Inverter' this will display a table and your Inverter SN - the format will be similar to : 60BHnnnnnnXnnn - copy and paste this into the config setting deviceSN: replacing the text `foxesscloud_inverter_serial_number`
+
+- `your_personal_api_key` is a personal api_key that is generated in your profile selection of your Foxesscloud account. To do this log into the Foxesscloud.com website, click on the 'profile icon' in the top right corner and select 'User Profile'. Then on the menu on the left hand side select 'API Management' and click 'Generate API Key, the long string that it generates should be copied and pasted into the platform config setting of your configuration.yaml apiKey: replacing the text `foxesscloud_personal_api_key` (see example above).
+
+- `your_inverter_id` in UUID that can be found on the foxesscloud in the url path on the `Inverter Details` page.
 ⚠️  Please make sure that this is exact value from inverter details page address between = and & character:
 ![Screenshot 2021-11-08 at 08 42 05](https://user-images.githubusercontent.com/2965092/140761535-edb12226-b2b8-4f2b-87ce-11b67476a9e2.png)
-- if you have more than one FoxESS device in your installation you can leverage optional `name` field in you config, if you want se some example check out [here](https://github.com/macxq/foxess-ha/issues/11#issuecomment-990228995)
+- Multi-inverter support - if you have more than one FoxESS device in your installation, you can leverage the optional `name` field in your config,
+   ```
+   sensor:
+     - platform: foxess
+       name: Fox1
+       deviceID: enter_your_inverter_id_1
+       deviceSN: enter_your_inverter_serial_number_1
+       apiKey: enter_your_personal_api_key_1
+     - platform: foxess
+       name: Fox2
+       deviceID: enter_your_inverter_id_2
+       deviceSN: enter_your_inverter_serial_number_2
+       apiKey: enter_your_personal_api_key_2
+   ```
+ 
 
 
 
@@ -52,7 +70,7 @@ sensor:
 
 HA Entity  | Measurement
 |---|---|
-Inverter |  on/off
+Inverter |  on-line/off-line/in-alarm
 Generation Power  |  kW 
 Grid Consumption Power  |  kW  
 FeedIn Power  |  kW  
@@ -60,6 +78,7 @@ Bat Discharge Power  |  kW
 Bat Charge Power  |  kW  
 Solar Power | kW
 Load Power | kW
+Meter2 Power | kW
 PV1 Current | A
 PV1 Power | kW
 PV1 Volt | V
@@ -93,7 +112,9 @@ Solar  |  kWh
 Load |  kWh 
 Bat Charge  |  kWh 
 Bat Discharge  |  kWh  
-Bat SoC | %
+Bat SoC | % (for single battery systems)
+Bat SoC1 | % (for dual battery systems)
+Bat SoC2 | % (for dual battery systems)
 Bat Temp | °C 
 Ambient Temp | °C
 Boost Temp | °C
@@ -102,11 +123,23 @@ Residual Energy | kWh
 minSoC | %
 minSoC on Grid | %
 Power Factor | %
-
+API Response Time | mS
 
 💡 If you want to understand energy generation per string check out this wiki [article](https://github.com/macxq/foxess-ha/wiki/Understand-PV-string-power-generation-using-foxess-ha)
 
 ## 🤔 Troubleshooting 
+
+API Error summary:
+
+- `{"errno":41930,"result":null}` ⟶ incorrect inverter id
+- `{"errno":40261,"result":null}` ⟶ incorrect inverter id
+- `{"errno":41807,"result":null}` ⟶ wrong user name or password
+- `{"errno":41808,"result":null}` ⟶ token expired
+- `{"errno":41809,"result":null}` ⟶ invalid token
+- `{"errno":40256,"result":null}` ⟶ Request header parameters are missing. Check whether the request headers are consistent with OpenAPI requirements.
+- `{"errno":40257,"result":null}` ⟶ Request body parameters are invalid. Check whether the request body is consistent with OpenAPI requirements.
+- `{"errno":40400,"result":null}` ⟶ The number of requests is too frequent. Please reduce the frequency of access.
+
 
 Increase log level in your `/configuration.yaml` by adding:
 
@@ -117,3 +150,29 @@ logger:
     custom_components.foxess: debug
 ```
 
+## FoxESS Open API Access and Limits
+FoxESS provide an OpenAPI that allows registered users to make request to return datasets.
+
+The OpenAPI access is limited and each user must have a personal_api_key to access it, this personal_api_key can be generated by logging into the FoxESS cloud wesbite - then click on the Profile Icon in the top right hand corner of the screen, select User Profile and then from the menu select API Management, click the button to 'Generate API Key' - this long string of numbers is your personal_api_key and must be used for access to your systems details.
+
+The OpenAPI has a limit of 1,440 API calls per day, after which the OpenAPI will stop responding to requests and generate a "40400" error.
+
+This sounds like a large number of calls, but bear in mind that multiple API calls have to be made on each scan to gain the complete dataset for a system.
+
+The integration paces the number of API calls that are made, with the following frequency -
+
+- Site status and plant details - every 15 minutes
+- Real time variables - every 5 minutes
+- Cumulative total reports (generation, feedin, gridConsumption, BatterychargeTotal, Batterydischargetotal, home load) - every 15 minutes
+- Daily Generation report (Daily Energy Generated - 'total yield') - every 30 minutes
+- Battery minSoC settings - every 30 minutes
+
+The integration is using approximately 24 API calls an hour (576 a day and well within the 1,440).
+
+If you have multiple inverters in your account, you will receive 1,440 calls per inverter, so for 2 inverters you will have 2,880 api calls.
+
+
+## 📚 Usefull wiki articles
+* [Understand PV string power generation using foxess ha](https://github.com/macxq/foxess-ha/wiki/Understand-PV-string-power-generation-using-foxess-ha)
+* [Sample sensors for better solar monitoring](https://github.com/macxq/foxess-ha/wiki/Sample-sensors-for-better-solar-monitoring)
+* [How to fix Energy Dashboard data (statistic data)](https://github.com/macxq/foxess-ha/wiki/How-to-fix-Energy-Dashboard-data-(statistic-data))


### PR DESCRIPTION
This release adds support for FoxESS H3 Pro inverter

Added PV5 and PV6 sensors (power, current, voltage)

Added bat_soc1 and bat_soc2 for dual battery systems (note original bat_soc will show as 'unknown' on dual battery systems)