### PR TITLE
Sets runningState to ‘164 - off-grid’ should datalogger go off-line

### DIFF
--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -170,6 +170,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             if not geterror:
                 if allData["addressbook"]["status"] is not None:
                     statetest = int(allData["addressbook"]["status"])
+                    if statetest in [3]:
+                        allData["raw"]["runningState"] = "164" # off-grid
                 else:
                     statetest = 0
                 _LOGGER.debug(" Statetest %s", statetest)


### PR DESCRIPTION
Set runningState to ‘164 - off-grid’ should datalogger report off-line in device detail.