### PR TITLE
Support for Fox EVO systems - do not use unless involved in testing

### DIFF
--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -1838,21 +1838,7 @@ class FoxESSInverter(CoordinatorEntity, SensorEntity):
         return None
 
     @property
-    def extra_state_attributes(self):
-        #if ATTR_DEVICE_SN not in self.coordinator.data["addressbook"]:
-        #    return {
-        #        ATTR_DEVICE_SN: 'not provided',
-        #        ATTR_PLANTNAME: 'not provided',
-        #        ATTR_MODULESN: 'not provided',
-        #        ATTR_DEVICE_TYPE: 'not provided',
-        #        ATTR_MASTER: 'not provided',
-        #        ATTR_MANAGER: 'not provided',
-        #        ATTR_SLAVE: 'not provided',
-        #        ATTR_BATTERYLIST: 'not provided',
-        #        ATTR_LASTCLOUDSYNC: datetime.now(),
-        #    }
-        #    allData["addressbook"][ATTR_DEVICE_SN] = "not provided"
-            
+    def extra_state_attributes(self):           
         if "status" not in self.coordinator.data["addressbook"]:
             _LOGGER.debug("addressbook status attributes None")
             return None


### PR DESCRIPTION
The Fox EVO system does not support the device detail (unlike every other Fox inverter - possibly an error?) and the api call fails.

The device list is correct and returns much of the information provided by the device detail api call, this modification adds a new config switch `Evo: true` and instead of making the device detail call, it will lookup the information in the device list and use that to fill the missing information.

Not all of the device detail information is not provided, however all of the essential items are provided to allow the integration to run correctly (until Fox correct the OpenApi for Evo systems).

This update also has an improved DNS and cloud failure retry mechanism.