### PR TITLE
Add a configuration flag to support reducing the number of API calls

### DIFF
--- a/custom_components/foxess_light/__init__.py
+++ b/custom_components/foxess_light/__init__.py
@@ -1,1 +1,1 @@
-"""The Foxess cloud integration with reduced api calls."""
+"""The Foxess cloud integration."""

--- a/custom_components/foxess_light/manifest.json
+++ b/custom_components/foxess_light/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "foxess",
-  "name": "HA & FoxESSCloud integration - Reduced API calls",
-  "codeowners": ["@francoisfernando"],
+  "name": "HA & FoxESSCloud integration",
+  "codeowners": ["@macxq","@r-amado","@fozzieuk"],
   "dependencies": ["rest"],
-  "documentation": "https://github.com/francoisfernando/foxess-ha",
+  "documentation": "https://github.com/macxq/foxess-ha",
   "iot_class": "local_polling",
-  "issue_tracker":"https://github.com/francoisfernando/foxess-ha",
+  "issue_tracker":"https://github.com/macxq/foxess-ha/issues",
   "requirements": ["random_user_agent"],
-  "version": "v0.5"  
+  "version": "v0.4"  
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,3 @@
 {
-  "name": "FoxESS Cloud Reduced API Calls"
+  "name": "FoxESS Cloud"
 }


### PR DESCRIPTION
### Why?

I recently installed a FoxESS battery with KH10 inverter in NSW, Australia. I also integrated my battery with a local VPP (Virtual Power Plant) provider/Energy Retailer which takes control of the battery.

Since I have a HA monitoring dashboard I also integrated using FoxESS HA plugin. But this lead to a problem as the combined API calls from VPP provider and HA plugin exceeded the 1440 API call limit per day. I really don't want to go the modbus route hence this little contribution to add a flag to run the FoxESS HACS plugin in a reduced api call mode.

### What

Added a new boolean configuration flag `reduceAPICalls` which will reduce the main telemetry api calls frequency from 5 minutes to 10 minutes and also reduce other calls 

### Testing

FoxESS API has an endpoint to retrieve the number of API calls remaining and using this in a jupyter notebook I have measured my VPP provider is using about 45 API calls per hour. Since 1440 API calls translates to 60 API calls per hour this leaves about 15 API calls which can be used by FoxESS plugin. With the changes I have implemented when this flag is enabled, it will reduce the number of calls to about 13.

#### The following file is from measuring call counts over 2 hours with VPP provider only making API calls

[call-counts-2025-12-19 12:35:19-2025-12-19 14:38:39.csv](https://github.com/user-attachments/files/24255341/call-counts-2025-12-19.12.35.19-2025-12-19.14.38.39.csv)



