### PR TITLE
Remove dependency for random_user_agent

### DIFF
--- a/custom_components/foxess/manifest.json
+++ b/custom_components/foxess/manifest.json
@@ -6,6 +6,5 @@
   "documentation": "https://github.com/macxq/foxess-ha",
   "iot_class": "local_polling",
   "issue_tracker":"https://github.com/macxq/foxess-ha/issues",
-  "requirements": ["random_user_agent"],
   "version": "v0.4"  
 }

--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -43,16 +43,6 @@ from homeassistant.util.ssl import SSLCipherList
 from homeassistant.helpers.icon import icon_for_battery_level
 import homeassistant.helpers.config_validation as cv
 
-from random_user_agent.user_agent import UserAgent
-from random_user_agent.params import SoftwareName, OperatingSystem
-
-software_names = [SoftwareName.CHROME.value]
-operating_systems = [OperatingSystem.WINDOWS.value, OperatingSystem.LINUX.value]
-user_agent_rotator = UserAgent(
-    software_names=software_names, operating_systems=operating_systems, limit=100
-)
-
-
 _LOGGER = logging.getLogger(__name__)
 _ENDPOINT_OA_DOMAIN = "https://www.foxesscloud.com"
 _ENDPOINT_OA_BATTERY_SETTINGS = "/op/v0/device/battery/soc/get?sn="


### PR DESCRIPTION
This removes the dependency on random_user_agent, which is no longer used as the User_Agent is coded to match the OpenApi development requirements.