### PR TITLE
Fix iot_class to cloud_polling

### DIFF
--- a/custom_components/foxess/manifest.json
+++ b/custom_components/foxess/manifest.json
@@ -4,7 +4,7 @@
   "codeowners": ["@macxq","@r-amado","@fozzieuk"],
   "dependencies": ["rest"],
   "documentation": "https://github.com/macxq/foxess-ha",
-  "iot_class": "local_polling",
+  "iot_class": "cloud_polling",
   "issue_tracker":"https://github.com/macxq/foxess-ha/issues",
   "version": "v0.4"  
 }


### PR DESCRIPTION
The integration uses the FoxESS Cloud API, not local device communication. Updates `iot_class` from `local_polling` to `cloud_polling`.