### PR TITLE
Fixing oversized data from Foxess API

### DIFF
--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -1563,7 +1563,7 @@ class FoxESSEnergyGenerated(CoordinatorEntity, SensorEntity):
                 energygenerated = self.coordinator.data["reportDailyGeneration"][
                     self._keyValue
                 ]
-                if energygenerated > 0:
+                if 0 < energygenerated < 1000:
                     energygenerated = round(energygenerated, 3)
                 else:
                     energygenerated = 0


### PR DESCRIPTION
Check if energygenerated is lower than 1000kWh what should resolve problem with oversized value form API. 