### PR TITLE
Add GUI configuration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install pytest pytest-homeassistant-custom-component
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,9 +16,10 @@ jobs:
         with:
           python-version: "3.13"
           cache: pip
+          cache-dependency-path: requirements_test.txt
 
       - name: Install dependencies
-        run: pip install pytest pytest-homeassistant-custom-component
+        run: pip install -r requirements_test.txt
 
       - name: Run tests
         run: pytest tests/ -v

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,10 +9,10 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           cache: pip

--- a/custom_components/foxess/__init__.py
+++ b/custom_components/foxess/__init__.py
@@ -1,1 +1,17 @@
 """The Foxess cloud integration."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+PLATFORMS = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up FoxESS from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/foxess/config_flow.py
+++ b/custom_components/foxess/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for FoxESS integration."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -52,9 +53,7 @@ def _build_headers(api_key: str, path: str) -> dict:
     }
 
 
-async def _fetch_device_list(
-    hass, api_key: str
-) -> tuple[list[dict], str | None]:
+async def _fetch_device_list(hass, api_key: str) -> tuple[list[dict], str | None]:
     """Fetch the device list from FoxESS Cloud.
 
     Returns (devices, error_key). On success error_key is None and devices
@@ -105,9 +104,7 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
         self._api_key: str | None = None
         self._devices: list[dict] | None = None
 
-    async def async_step_user(
-        self, user_input: dict | None = None
-    ) -> ConfigFlowResult:
+    async def async_step_user(self, user_input: dict | None = None) -> ConfigFlowResult:
         """Handle the initial step — collect API key and discover devices."""
         errors: dict[str, str] = {}
 
@@ -123,7 +120,10 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema({vol.Required(CONF_API_KEY): str}),
+                user_input or {},
+            ),
             errors=errors,
         )
 
@@ -139,15 +139,15 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             device_sn = user_input[CONF_DEVICE_SN]
             name = user_input.get(CONF_NAME, DEFAULT_NAME)
-            await self.async_set_unique_id(device_sn)
-            self._abort_if_unique_id_configured()
-            existing_names = {
-                entry.data.get(CONF_NAME)
-                for entry in self.hass.config_entries.async_entries(DOMAIN)
-            }
-            if name in existing_names:
+
+            current_entries = self._async_current_entries()
+            if any(e.unique_id == device_sn for e in current_entries):
+                errors[CONF_DEVICE_SN] = "already_configured"
+            if any(e.data.get(CONF_NAME) == name for e in current_entries):
                 errors[CONF_NAME] = "name_already_in_use"
-            else:
+
+            if not errors:
+                await self.async_set_unique_id(device_sn)
                 return self.async_create_entry(
                     title=device_sn,
                     data={
@@ -162,26 +162,27 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
         options = [
             SelectOptionDict(
                 value=d["deviceSN"],
-                label=(
-                    f"{d['deviceSN']} ({d.get('deviceType', '?')})"
-                ),
+                label=(f"{d['deviceSN']} ({d.get('deviceType', '?')})"),
             )
             for d in self._devices
         ]
 
         return self.async_show_form(
             step_id="device",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_DEVICE_SN): SelectSelector(
-                        SelectSelectorConfig(
-                            options=options,
-                            mode=SelectSelectorMode.DROPDOWN,
-                        )
-                    ),
-                    vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
-                    vol.Optional(CONF_EXTPV, default=False): bool,
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(
+                    {
+                        vol.Required(CONF_DEVICE_SN): SelectSelector(
+                            SelectSelectorConfig(
+                                options=options,
+                                mode=SelectSelectorMode.DROPDOWN,
+                            )
+                        ),
+                        vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
+                        vol.Optional(CONF_EXTPV, default=False): bool,
+                    }
+                ),
+                user_input or {},
             ),
             errors=errors,
         )

--- a/custom_components/foxess/config_flow.py
+++ b/custom_components/foxess/config_flow.py
@@ -19,20 +19,22 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .sensor import GetAuth
+from .sensor import (
+    _ENDPOINT_OA_DOMAIN,
+    CONF_APIKEY,
+    CONF_DEVICEID,
+    CONF_DEVICESN,
+    CONF_EXTPV,
+    DEFAULT_NAME,
+    GetAuth,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "foxess"
 
-CONF_API_KEY = "apiKey"
-CONF_DEVICE_SN = "deviceSN"
-CONF_DEVICE_ID = "deviceID"
-CONF_EXTPV = "extendPV"
-DEFAULT_NAME = "FoxESS"
-
-_DEVICE_LIST_ENDPOINT = "https://www.foxesscloud.com/op/v0/device/list"
 _DEVICE_LIST_PATH = "/op/v0/device/list"
+_DEVICE_LIST_ENDPOINT = _ENDPOINT_OA_DOMAIN + _DEVICE_LIST_PATH
 
 
 async def _fetch_device_list(hass, api_key: str) -> tuple[list[dict], str | None]:
@@ -91,7 +93,7 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            api_key = user_input[CONF_API_KEY]
+            api_key = user_input[CONF_APIKEY]
             devices, error = await _fetch_device_list(self.hass, api_key)
             if error:
                 errors["base"] = error
@@ -103,7 +105,7 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
-                vol.Schema({vol.Required(CONF_API_KEY): str}),
+                vol.Schema({vol.Required(CONF_APIKEY): str}),
                 user_input or {},
             ),
             errors=errors,
@@ -119,12 +121,12 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            device_sn = user_input[CONF_DEVICE_SN]
+            device_sn = user_input[CONF_DEVICESN]
             name = user_input.get(CONF_NAME, DEFAULT_NAME)
 
             current_entries = self._async_current_entries()
             if any(e.unique_id == device_sn for e in current_entries):
-                errors[CONF_DEVICE_SN] = "already_configured"
+                errors[CONF_DEVICESN] = "already_configured"
             if any(e.data.get(CONF_NAME) == name for e in current_entries):
                 errors[CONF_NAME] = "name_already_in_use"
 
@@ -133,9 +135,9 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=device_sn,
                     data={
-                        CONF_API_KEY: self._api_key,
-                        CONF_DEVICE_SN: device_sn,
-                        CONF_DEVICE_ID: device_sn,
+                        CONF_APIKEY: self._api_key,
+                        CONF_DEVICESN: device_sn,
+                        CONF_DEVICEID: device_sn,
                         CONF_NAME: name,
                         CONF_EXTPV: user_input.get(CONF_EXTPV, False),
                     },
@@ -154,7 +156,7 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=self.add_suggested_values_to_schema(
                 vol.Schema(
                     {
-                        vol.Required(CONF_DEVICE_SN): SelectSelector(
+                        vol.Required(CONF_DEVICESN): SelectSelector(
                             SelectSelectorConfig(
                                 options=options,
                                 mode=SelectSelectorMode.DROPDOWN,
@@ -183,17 +185,17 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
         reauth_entry = self._get_reauth_entry()
 
         if user_input is not None:
-            _, error = await _fetch_device_list(self.hass, user_input[CONF_API_KEY])
+            _, error = await _fetch_device_list(self.hass, user_input[CONF_APIKEY])
             if error in (None, "no_devices"):
                 return self.async_update_reload_and_abort(
                     reauth_entry,
-                    data_updates={CONF_API_KEY: user_input[CONF_API_KEY]},
+                    data_updates={CONF_APIKEY: user_input[CONF_APIKEY]},
                 )
             errors["base"] = error
 
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
-            description_placeholders={"device_sn": reauth_entry.data[CONF_DEVICE_SN]},
+            data_schema=vol.Schema({vol.Required(CONF_APIKEY): str}),
+            description_placeholders={"device_sn": reauth_entry.data[CONF_DEVICESN]},
             errors=errors,
         )

--- a/custom_components/foxess/config_flow.py
+++ b/custom_components/foxess/config_flow.py
@@ -27,6 +27,7 @@ DOMAIN = "foxess"
 CONF_API_KEY = "apiKey"
 CONF_DEVICE_SN = "deviceSN"
 CONF_DEVICE_ID = "deviceID"
+CONF_EXTPV = "extendPV"
 DEFAULT_NAME = "FoxESS"
 
 _DEVICE_LIST_ENDPOINT = "https://www.foxesscloud.com/op/v0/device/list"
@@ -145,6 +146,7 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_DEVICE_SN: device_sn,
                     CONF_DEVICE_ID: device_sn,
                     CONF_NAME: name,
+                    CONF_EXTPV: user_input.get(CONF_EXTPV, False),
                 },
             )
 
@@ -169,6 +171,7 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
                         )
                     ),
                     vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
+                    vol.Optional(CONF_EXTPV, default=False): bool,
                 }
             ),
         )

--- a/custom_components/foxess/config_flow.py
+++ b/custom_components/foxess/config_flow.py
@@ -1,0 +1,203 @@
+"""Config flow for FoxESS integration."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+import hashlib
+import logging
+import time
+from typing import Any
+
+from aiohttp import ClientError
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "foxess"
+
+CONF_API_KEY = "apiKey"
+CONF_DEVICE_SN = "deviceSN"
+CONF_DEVICE_ID = "deviceID"
+DEFAULT_NAME = "FoxESS"
+
+_DEVICE_LIST_ENDPOINT = "https://www.foxesscloud.com/op/v0/device/list"
+_DEVICE_LIST_PATH = "/op/v0/device/list"
+
+
+def _build_headers(api_key: str, path: str) -> dict:
+    timestamp = round(time.time() * 1000)
+    signature_text = rf"{path}\r\n{api_key}\r\n{timestamp}"
+    signature = hashlib.md5(signature_text.encode("UTF-8")).hexdigest()
+    return {
+        "token": api_key,
+        "lang": "en",
+        "timestamp": str(timestamp),
+        "Content-Type": "application/json",
+        "signature": signature,
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Connection": "close",
+    }
+
+
+async def _fetch_device_list(
+    hass, api_key: str
+) -> tuple[list[dict], str | None]:
+    """Fetch the device list from FoxESS Cloud.
+
+    Returns (devices, error_key). On success error_key is None and devices
+    contains the list of device dicts from the API (deviceSN, deviceType, etc.).
+    """
+    headers = _build_headers(api_key, _DEVICE_LIST_PATH)
+    session = async_get_clientsession(hass, verify_ssl=False)
+    try:
+        # This assumes that the user has a maximum of 25 inverters.
+        resp = await session.post(
+            _DEVICE_LIST_ENDPOINT,
+            headers=headers,
+            json={"currentPage": 1, "pageSize": 25},
+            timeout=30,
+        )
+        if resp.status == 401:
+            _LOGGER.warning("FoxESS API rejected credentials (HTTP 401)")
+            return [], "invalid_auth"
+        data = await resp.json(content_type=None)
+    except ClientError:
+        _LOGGER.exception("Connection error fetching FoxESS device list")
+        return [], "cannot_connect"
+
+    if not isinstance(data, dict):
+        _LOGGER.error("Unexpected response body from FoxESS device list API: %r", data)
+        return [], "cannot_connect"
+
+    errno = data.get("errno", -1)
+    if errno != 0:
+        _LOGGER.error("Unexpected errno from FoxESS device list API: %s", errno)
+        return [], "cannot_connect"
+
+    devices: list[dict] = data.get("result", {}).get("data", [])
+    if not devices:
+        return [], "no_devices"
+
+    return devices, None
+
+
+
+class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for FoxESS."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialise the config flow."""
+        self._api_key: str | None = None
+        self._devices: list[dict] | None = None
+
+    async def async_step_user(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step — collect API key and discover devices."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            api_key = user_input[CONF_API_KEY]
+            devices, error = await _fetch_device_list(self.hass, api_key)
+            if error:
+                errors["base"] = error
+            else:
+                self._api_key = api_key
+                self._devices = devices
+                return await self.async_step_device()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
+            errors=errors,
+        )
+
+    async def async_step_device(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        """Handle device selection."""
+        assert self._api_key is not None
+        assert self._devices is not None
+
+        if user_input is not None:
+            device_sn = user_input[CONF_DEVICE_SN]
+            name = user_input.get(CONF_NAME, DEFAULT_NAME)
+            await self.async_set_unique_id(device_sn)
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=device_sn,
+                data={
+                    CONF_API_KEY: self._api_key,
+                    CONF_DEVICE_SN: device_sn,
+                    CONF_DEVICE_ID: device_sn,
+                    CONF_NAME: name,
+                },
+            )
+
+        options = [
+            SelectOptionDict(
+                value=d["deviceSN"],
+                label=(
+                    f"{d['deviceSN']} ({d.get('deviceType', '?')})"
+                ),
+            )
+            for d in self._devices
+        ]
+
+        return self.async_show_form(
+            step_id="device",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_DEVICE_SN): SelectSelector(
+                        SelectSelectorConfig(
+                            options=options,
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Optional(CONF_NAME, default=DEFAULT_NAME): str,
+                }
+            ),
+        )
+
+    async def async_step_reauth(
+        self, _entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Triggered automatically by HA when ConfigEntryAuthFailed is raised."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        """Show a form asking only for the new API key."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            _, error = await _fetch_device_list(self.hass, user_input[CONF_API_KEY])
+            if error in (None, "no_devices"):
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates={CONF_API_KEY: user_input[CONF_API_KEY]},
+                )
+            errors["base"] = error
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
+            description_placeholders={"device_sn": reauth_entry.data[CONF_DEVICE_SN]},
+            errors=errors,
+        )

--- a/custom_components/foxess/config_flow.py
+++ b/custom_components/foxess/config_flow.py
@@ -134,21 +134,30 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
         assert self._api_key is not None
         assert self._devices is not None
 
+        errors: dict[str, str] = {}
+
         if user_input is not None:
             device_sn = user_input[CONF_DEVICE_SN]
             name = user_input.get(CONF_NAME, DEFAULT_NAME)
             await self.async_set_unique_id(device_sn)
             self._abort_if_unique_id_configured()
-            return self.async_create_entry(
-                title=device_sn,
-                data={
-                    CONF_API_KEY: self._api_key,
-                    CONF_DEVICE_SN: device_sn,
-                    CONF_DEVICE_ID: device_sn,
-                    CONF_NAME: name,
-                    CONF_EXTPV: user_input.get(CONF_EXTPV, False),
-                },
-            )
+            existing_names = {
+                entry.data.get(CONF_NAME)
+                for entry in self.hass.config_entries.async_entries(DOMAIN)
+            }
+            if name in existing_names:
+                errors[CONF_NAME] = "name_already_in_use"
+            else:
+                return self.async_create_entry(
+                    title=device_sn,
+                    data={
+                        CONF_API_KEY: self._api_key,
+                        CONF_DEVICE_SN: device_sn,
+                        CONF_DEVICE_ID: device_sn,
+                        CONF_NAME: name,
+                        CONF_EXTPV: user_input.get(CONF_EXTPV, False),
+                    },
+                )
 
         options = [
             SelectOptionDict(
@@ -174,6 +183,7 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Optional(CONF_EXTPV, default=False): bool,
                 }
             ),
+            errors=errors,
         )
 
     async def async_step_reauth(

--- a/custom_components/foxess/config_flow.py
+++ b/custom_components/foxess/config_flow.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-import hashlib
 import logging
-import time
 from typing import Any
 
 from aiohttp import ClientError
@@ -21,6 +19,8 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
+from .sensor import GetAuth
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "foxess"
@@ -35,31 +35,13 @@ _DEVICE_LIST_ENDPOINT = "https://www.foxesscloud.com/op/v0/device/list"
 _DEVICE_LIST_PATH = "/op/v0/device/list"
 
 
-def _build_headers(api_key: str, path: str) -> dict:
-    timestamp = round(time.time() * 1000)
-    signature_text = rf"{path}\r\n{api_key}\r\n{timestamp}"
-    signature = hashlib.md5(signature_text.encode("UTF-8")).hexdigest()
-    return {
-        "token": api_key,
-        "lang": "en",
-        "timestamp": str(timestamp),
-        "Content-Type": "application/json",
-        "signature": signature,
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-        ),
-        "Connection": "close",
-    }
-
-
 async def _fetch_device_list(hass, api_key: str) -> tuple[list[dict], str | None]:
     """Fetch the device list from FoxESS Cloud.
 
     Returns (devices, error_key). On success error_key is None and devices
     contains the list of device dicts from the API (deviceSN, deviceType, etc.).
     """
-    headers = _build_headers(api_key, _DEVICE_LIST_PATH)
+    headers = GetAuth().get_signature(token=api_key, path=_DEVICE_LIST_PATH)
     session = async_get_clientsession(hass, verify_ssl=False)
     try:
         # This assumes that the user has a maximum of 25 inverters.

--- a/custom_components/foxess/config_flow.py
+++ b/custom_components/foxess/config_flow.py
@@ -26,6 +26,7 @@ from .sensor import (
     CONF_DEVICESN,
     CONF_EXTPV,
     DEFAULT_NAME,
+    YAML_CONFIGS_KEY,
     GetAuth,
 )
 
@@ -125,9 +126,16 @@ class FoxESSConfigFlow(ConfigFlow, domain=DOMAIN):
             name = user_input.get(CONF_NAME, DEFAULT_NAME)
 
             current_entries = self._async_current_entries()
-            if any(e.unique_id == device_sn for e in current_entries):
+            yaml_configs = self.hass.data.get(YAML_CONFIGS_KEY, {})
+
+            if device_sn in yaml_configs:
+                errors[CONF_DEVICESN] = "yaml_device_already_configured"
+            elif any(e.unique_id == device_sn for e in current_entries):
                 errors[CONF_DEVICESN] = "already_configured"
-            if any(e.data.get(CONF_NAME) == name for e in current_entries):
+
+            if any(cfg.get(CONF_NAME) == name for cfg in yaml_configs.values()):
+                errors[CONF_NAME] = "yaml_name_already_in_use"
+            elif any(e.data.get(CONF_NAME) == name for e in current_entries):
                 errors[CONF_NAME] = "name_already_in_use"
 
             if not errors:

--- a/custom_components/foxess/manifest.json
+++ b/custom_components/foxess/manifest.json
@@ -2,9 +2,10 @@
   "domain": "foxess",
   "name": "HA & FoxESSCloud integration",
   "codeowners": ["@macxq","@r-amado","@fozzieuk"],
+  "config_flow": true,
   "dependencies": ["rest"],
   "documentation": "https://github.com/macxq/foxess-ha",
   "iot_class": "local_polling",
   "issue_tracker":"https://github.com/macxq/foxess-ha/issues",
-  "version": "v0.4"  
+  "version": "v0.4"
 }

--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
     UnitOfReactivePower,
     PERCENTAGE,
 )
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -83,6 +84,7 @@ CONF_EVO = "Evo"
 RETRY_NEXT_SLOT = -1
 RETRY_IN_5_MINS = 25
 DNS_ERROR = 101
+_AUTH_ERRNO = {40256, 41808}  # Invalid/empty API key per FoxESS OpenAPI docs
 
 DEFAULT_NAME = "FoxESS"
 DEFAULT_VERIFY_SSL = False  # True
@@ -109,8 +111,23 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 token = None
 
 
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up FoxESS sensors from a config entry."""
+    await _async_setup_foxess(
+        hass,
+        config_entry.data,
+        async_add_entities,
+        config_entry,
+    )
+
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the FoxESS sensor."""
+    await _async_setup_foxess(hass, config, async_add_entities)
+
+
+async def _async_setup_foxess(hass, config, async_add_entities, config_entry=None):
+    """Shared setup logic for platform and config entry."""
     global LastHour, timeslice, last_api, RestrictGetVar, xtzone, V1_Api, Evo
     Evo = False
     name = config.get(CONF_NAME)
@@ -179,6 +196,17 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                     geterror = await getOADeviceList(hass, allData, devicesn, apiKey)
                 else:
                     geterror = await getOADeviceDetail(hass, allData, devicesn, apiKey)
+                if isinstance(geterror, int) and geterror in _AUTH_ERRNO:
+                    if config_entry is not None:
+                        raise ConfigEntryAuthFailed(
+                            f"FoxESS API key rejected (errno {geterror})"
+                        )
+                    _LOGGER.error(
+                        "FoxESS API authentication failed (errno %s). "
+                        "Update your apiKey in configuration.yaml and restart.",
+                        geterror,
+                    )
+                    return allData
                 await asyncio.sleep(1)  # OpenAPI demand
             if not geterror:
                 if allData["addressbook"]["status"] is not None:
@@ -196,6 +224,17 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                         await asyncio.sleep(1)  # OpenAPI demand
                     # main real time data fetch, followed by reports
                     geterror = await getRaw(hass, allData, apiKey, devicesn)
+                    if isinstance(geterror, int) and geterror in _AUTH_ERRNO:
+                        if config_entry is not None:
+                            raise ConfigEntryAuthFailed(
+                                f"FoxESS API key rejected (errno {geterror})"
+                            )
+                        _LOGGER.error(
+                            "FoxESS API authentication failed (errno %s). "
+                            "Update your apiKey in configuration.yaml and restart.",
+                            geterror,
+                        )
+                        return allData
                     if not geterror:
                         if tslice % 15 == 0:  # do at startup and every 15 minutes
                             await asyncio.sleep(1)  # OpenAPI demand limit
@@ -278,11 +317,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
-        # Name of the data. For logging purposes.
         name=DEFAULT_NAME,
         update_method=async_update_data,
-        # Polling interval. Will only be polled if there are subscribers.
         update_interval=SCAN_INTERVAL,
+        config_entry=config_entry,
     )
 
     await coordinator.async_refresh()
@@ -801,7 +839,7 @@ async def getOADeviceDetail(hass, allData, devicesn, apiKey):
             return False
         else:
             _LOGGER.error("OA Device Detail Bad Response: %s", response)
-            return True
+            return response["errno"]
 
 
 async def getOADeviceList(hass, allData, devicesn, apiKey):
@@ -1101,17 +1139,17 @@ async def getRaw(hass, allData, apiKey, devicesn):
 
     # build the devicesn string
     if V1_Api:
-        dsn = '{"sns":["' + devicesn + '"] }' 
+        dsn = '{"sns":["' + devicesn + '"] }'
     else:
-        dsn = '{"sn":"' + devicesn + '" }' 
+        dsn = '{"sn":"' + devicesn + '" }'
 
     if RestrictGetVar:
         _LOGGER.debug("Getting Device Variable in restricted mode")
         # build the devicesn string
         if V1_Api:
-            dsn = '{"sns":["' + devicesn + '"] ' 
+            dsn = '{"sns":["' + devicesn + '"] '
         else:
-            dsn = '{"sn":"' + devicesn + '"' 
+            dsn = '{"sn":"' + devicesn + '"'
 
         rawData = (
             dsn + ',"variables":["ambientTemperation", "batChargePower", "batCurrent", "batCurrent_1", "batCurrent_2", "batDischargePower", "batTemperature", "batTemperature_1", "batTemperature_2", "batVolt", "batVolt_1", "batVolt_2", "boostTemperation", "chargeTemperature", "dspTemperature", "epsCurrentR", "epsCurrentS", "epsCurrentT", "epsPower", "epsPowerR", "epsPowerS", "epsPowerT", "epsVoltR", "epsVoltS", "epsVoltT", "feedinPower", "generationPower", "gridConsumptionPower", "input", "invBatCurrent", "invBatPower", "invBatVolt", "invTemperation", "loadsPower", "loadsPowerR", "loadsPowerS", "loadsPowerT", "meterPower", "meterPower2", "meterPowerR", "meterPowerS", "meterPowerT", "PowerFactor", "pv1Current", "pv1Power", "pv1Volt", "pv2Current", "pv2Power", "pv2Volt", "pv3Current", "pv3Power", "pv3Volt", "pv4Current", "pv4Power", "pv4Volt", "pvPower", "RCurrent", "ReactivePower", "RFreq", "RPower", "RVolt", "SCurrent", "SFreq", "SoC", "SPower", "SVolt", "TCurrent", "TFreq", "TPower", "TVolt", "SoC_1", "Soc_2", "ResidualEnergy", "energyThroughput", "runningState", "currentFaultCount"] }'
@@ -1317,7 +1355,7 @@ async def getRaw(hass, allData, apiKey, devicesn):
             return False
         else:
             _LOGGER.debug("OA Device Variables Bad Response: %s", response)
-            return True
+            return response["errno"]
 
 
 class FoxESSPowerString(CoordinatorEntity, SensorEntity):
@@ -1899,7 +1937,7 @@ class FoxESSInverter(CoordinatorEntity, SensorEntity):
         return None
 
     @property
-    def extra_state_attributes(self):           
+    def extra_state_attributes(self):
         if "status" not in self.coordinator.data["addressbook"]:
             _LOGGER.debug("addressbook status attributes None")
             return None

--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from datetime import timedelta
 from datetime import datetime
 from dateutil import parser
+import enum
 import time
 import logging
 import json
@@ -83,8 +84,21 @@ CONF_V1_API = "Use_V1_Api"
 CONF_EVO = "Evo"
 RETRY_NEXT_SLOT = -1
 RETRY_IN_5_MINS = 25
-DNS_ERROR = 101
 _AUTH_ERRNO = {40256, 41808}  # Invalid/empty API key per FoxESS OpenAPI docs
+
+
+class FetchResult(enum.Enum):
+    """Result of a FoxESS Cloud API fetch call."""
+
+    OK = "ok"
+    ERROR = "error"
+    AUTH_FAILED = "auth_failed"
+    DNS_TIMEOUT = "dns_timeout"
+
+    def __bool__(self) -> bool:
+        """Return False for OK so callers can use `if not result:` for success."""
+        return self is not FetchResult.OK
+
 
 DEFAULT_NAME = "FoxESS"
 DEFAULT_VERIFY_SSL = False  # True
@@ -188,7 +202,7 @@ async def _async_setup_foxess(hass, config, async_add_entities, config_entry=Non
         if tslice % 5 == 0:
             _LOGGER.debug("Main Poll, interval: %s, %s", devicesn, timeslice[devicesn])
             # try the openapi see if we get a response
-            geterror = False
+            geterror = FetchResult.OK
             if tslice % 15 == 0:
                 # get device detail at startup, then every 15 minutes to save api calls
                 if Evo:
@@ -196,15 +210,12 @@ async def _async_setup_foxess(hass, config, async_add_entities, config_entry=Non
                     geterror = await getOADeviceList(hass, allData, devicesn, apiKey)
                 else:
                     geterror = await getOADeviceDetail(hass, allData, devicesn, apiKey)
-                if isinstance(geterror, int) and geterror in _AUTH_ERRNO:
+                if geterror is FetchResult.AUTH_FAILED:
                     if config_entry is not None:
-                        raise ConfigEntryAuthFailed(
-                            f"FoxESS API key rejected (errno {geterror})"
-                        )
+                        raise ConfigEntryAuthFailed("FoxESS API key rejected")
                     _LOGGER.error(
-                        "FoxESS API authentication failed (errno %s). "
-                        "Update your apiKey in configuration.yaml and restart.",
-                        geterror,
+                        "FoxESS API authentication failed. "
+                        "Update your apiKey in configuration.yaml and restart."
                     )
                     return allData
                 await asyncio.sleep(1)  # OpenAPI demand
@@ -224,15 +235,12 @@ async def _async_setup_foxess(hass, config, async_add_entities, config_entry=Non
                         await asyncio.sleep(1)  # OpenAPI demand
                     # main real time data fetch, followed by reports
                     geterror = await getRaw(hass, allData, apiKey, devicesn)
-                    if isinstance(geterror, int) and geterror in _AUTH_ERRNO:
+                    if geterror is FetchResult.AUTH_FAILED:
                         if config_entry is not None:
-                            raise ConfigEntryAuthFailed(
-                                f"FoxESS API key rejected (errno {geterror})"
-                            )
+                            raise ConfigEntryAuthFailed("FoxESS API key rejected")
                         _LOGGER.error(
-                            "FoxESS API authentication failed (errno %s). "
-                            "Update your apiKey in configuration.yaml and restart.",
-                            geterror,
+                            "FoxESS API authentication failed. "
+                            "Update your apiKey in configuration.yaml and restart."
                         )
                         return allData
                     if not geterror:
@@ -249,7 +257,7 @@ async def _async_setup_foxess(hass, config, async_add_entities, config_entry=Non
                             else:
                                 _LOGGER.debug("getReport False")
                             if geterror:
-                                geterror = False
+                                geterror = FetchResult.OK
                                 allData["online"] = False
                                 tslice = RETRY_IN_5_MINS  # retry in 5 minutes
                     else:
@@ -263,7 +271,7 @@ async def _async_setup_foxess(hass, config, async_add_entities, config_entry=Non
                             allData["online"] = False
                             tslice = RETRY_IN_5_MINS  # retry in 5 minutes
                         else:
-                            if geterror==DNS_ERROR:
+                            if geterror is FetchResult.DNS_TIMEOUT:
                                 _LOGGER.warning("Fox Cloud - DNS fail, retry in 1 minute")
                                 # retry in 1 minute
                                 if tslice != 0:
@@ -275,7 +283,7 @@ async def _async_setup_foxess(hass, config, async_add_entities, config_entry=Non
                                 _LOGGER.debug("slowing retry response for SN: %s", devicesn)
                                 allData["online"] = False
                                 tslice = RETRY_IN_5_MINS  # retry in 5 minutes
-                        geterror = False
+                        geterror = FetchResult.OK
                 else:
                     if statetest == 3:
                         # The inverter is off-line, no raw data polling, don't update entities
@@ -292,7 +300,7 @@ async def _async_setup_foxess(hass, config, async_add_entities, config_entry=Non
             else:
                 _LOGGER.warning("%s Cloud timeout on Device Detail, retry in 1 minute.", name)
 
-            if geterror is not False:
+            if geterror is not FetchResult.OK:
                 allData["online"] = False
                 if tslice != 0:
                     tslice = tslice-1
@@ -815,7 +823,7 @@ async def getOADeviceDetail(hass, allData, devicesn, apiKey):
 
     if restOADeviceDetail.data is None or restOADeviceDetail.data == "":
         _LOGGER.debug("Unable to get OA Device Detail from FoxESS Cloud")
-        return True
+        return FetchResult.ERROR
     else:
         response = json.loads(restOADeviceDetail.data)
         if response["errno"] == 0 and (response["msg"]=='success' or response["msg"]=='Operation successful'):
@@ -836,10 +844,10 @@ async def getOADeviceDetail(hass, allData, devicesn, apiKey):
             else:
                 _LOGGER.debug("OA Device Detail System has No Battery: %s", testBattery)
                 allData["addressbook"][ATTR_BATTERYLIST] = "No Battery"
-            return False
+            return FetchResult.OK
         else:
             _LOGGER.error("OA Device Detail Bad Response: %s", response)
-            return response["errno"]
+            return FetchResult.AUTH_FAILED if response["errno"] in _AUTH_ERRNO else FetchResult.ERROR
 
 
 async def getOADeviceList(hass, allData, devicesn, apiKey):
@@ -873,7 +881,7 @@ async def getOADeviceList(hass, allData, devicesn, apiKey):
 
     if restOADeviceList.data is None or restOADeviceList.data == "":
         _LOGGER.debug("Unable to get OA Device List from FoxESS Cloud")
-        return True
+        return FetchResult.ERROR
     else:
         response = json.loads(restOADeviceList.data)
         if response["errno"] == 0 and (response["msg"]=='success' or response["msg"]=='Operation successful'):
@@ -902,10 +910,10 @@ async def getOADeviceList(hass, allData, devicesn, apiKey):
                 _LOGGER.debug("OA Device List System has No Battery: %s", testBattery)
                 allData["addressbook"][ATTR_BATTERYLIST] = "No Battery"
 
-            return False
+            return FetchResult.OK
         else:
             _LOGGER.error("OA Device List Bad Response: %s", response)
-            return True
+            return FetchResult.AUTH_FAILED if response["errno"] in _AUTH_ERRNO else FetchResult.ERROR
 
 
 async def getOABatterySettings(hass, allData, devicesn, apiKey):
@@ -940,7 +948,7 @@ async def getOABatterySettings(hass, allData, devicesn, apiKey):
 
         if restOABatterySettings.data is None:
             _LOGGER.debug("Unable to get OA Battery Settings from FoxESS Cloud")
-            return True
+            return FetchResult.ERROR
         else:
             response = json.loads(restOABatterySettings.data)
             if response["errno"] == 0 and (response["msg"]=='success' or response["msg"]=='Operation successful'):
@@ -957,15 +965,15 @@ async def getOABatterySettings(hass, allData, devicesn, apiKey):
                     minSoc,
                     minSocOnGrid,
                 )
-                return False
+                return FetchResult.OK
             else:
                 _LOGGER.error("OA Battery Settings Bad Response: %s", response)
-                return True
+                return FetchResult.ERROR
     else:
         # device detail reports no battery fitted so reset these variables to show unknown
         allData["battery"]["minSoc"] = None
         allData["battery"]["minSocOnGrid"] = None
-        return False
+        return FetchResult.OK
 
 
 async def getReport(hass, allData, apiKey, devicesn):
@@ -1010,7 +1018,7 @@ async def getReport(hass, allData, apiKey, devicesn):
 
     if restOAReport.data is None or restOAReport.data == "":
         _LOGGER.debug("Unable to get OA Report from FoxESS Cloud")
-        return True
+        return FetchResult.ERROR
     else:
         # Openapi responded so process data
         response = json.loads(restOAReport.data)
@@ -1041,10 +1049,10 @@ async def getReport(hass, allData, apiKey, devicesn):
                 _LOGGER.debug(
                     "OA Report Variable: %s, Total: %s", variableName, cumulative_total
                 )
-            return False
+            return FetchResult.OK
         else:
             _LOGGER.debug("OA Report Bad Response: %s %s ", response, restOAReport.data)
-            return True
+            return FetchResult.ERROR
 
 
 async def getReportDailyGeneration(hass, allData, apiKey, devicesn):
@@ -1078,7 +1086,7 @@ async def getReportDailyGeneration(hass, allData, apiKey, devicesn):
 
     if restOAgen.data is None or restOAgen.data == "":
         _LOGGER.debug("Unable to get OA Daily Generation Report from FoxESS Cloud")
-        return True
+        return FetchResult.ERROR
     else:
         response = json.loads(restOAgen.data)
         if response["errno"] == 0 and (response["msg"]=='success' or response["msg"]=='Operation successful'):
@@ -1122,14 +1130,14 @@ async def getReportDailyGeneration(hass, allData, apiKey, devicesn):
                     "OA Daily Generation Report data: cumulative value %s ",
                     parsed["cumulative"],
                 )
-            return False
+            return FetchResult.OK
         else:
             _LOGGER.debug(
                 "OA Daily Generation Report Bad Response: %s %s ",
                 response,
                 restOAgen.data,
             )
-            return True
+            return FetchResult.ERROR
 
 
 async def getRaw(hass, allData, apiKey, devicesn):
@@ -1192,12 +1200,12 @@ async def getRaw(hass, allData, apiKey, devicesn):
         _LOGGER.debug("Getvar exception: %s", lastex)
         if "Timeout while contacting DNS servers" in lastex:
             _LOGGER.debug("Getvar DNS exception: %s", lastex)
-            return DNS_ERROR
+            return FetchResult.DNS_TIMEOUT
             # [Timeout while contacting DNS servers]
 
     if restOADeviceVariables.data is None or restOADeviceVariables.data == "":
         _LOGGER.debug("Unable to get OA Variables from FoxESS Cloud")
-        return True
+        return FetchResult.ERROR
     else:
         # Openapi responded correctly
         response = json.loads(restOADeviceVariables.data)
@@ -1352,10 +1360,10 @@ async def getRaw(hass, allData, apiKey, devicesn):
                                     hasBat,
                                 )
 
-            return False
+            return FetchResult.OK
         else:
             _LOGGER.debug("OA Device Variables Bad Response: %s", response)
-            return response["errno"]
+            return FetchResult.AUTH_FAILED if response["errno"] in _AUTH_ERRNO else FetchResult.ERROR
 
 
 class FoxESSPowerString(CoordinatorEntity, SensorEntity):

--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -86,6 +86,10 @@ RETRY_NEXT_SLOT = -1
 RETRY_IN_5_MINS = 25
 _AUTH_ERRNO = {40256, 41808}  # Invalid/empty API key per FoxESS OpenAPI docs
 
+# Key under hass.data where YAML-configured device info is stored so the
+# config flow can detect conflicts and preserve the original deviceID.
+YAML_CONFIGS_KEY = "foxess_yaml_configs"
+
 
 class FetchResult(enum.Enum):
     """Result of a FoxESS Cloud API fetch call."""
@@ -137,6 +141,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the FoxESS sensor."""
+    # Advertise YAML config so the config flow can detect conflicts and
+    # preserve the original deviceID (which may differ from deviceSN).
+    yaml_configs = hass.data.setdefault(YAML_CONFIGS_KEY, {})
+    yaml_configs[config[CONF_DEVICESN]] = {
+        CONF_DEVICEID: config.get(CONF_DEVICEID),
+        CONF_NAME: config.get(CONF_NAME, DEFAULT_NAME),
+    }
     await _async_setup_foxess(hass, config, async_add_entities)
 
 

--- a/custom_components/foxess/strings.json
+++ b/custom_components/foxess/strings.json
@@ -1,0 +1,38 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "FoxESS Cloud",
+        "description": "Enter your FoxESS OpenAPI key to fetch your devices",
+        "data": {
+          "apiKey": "API Key"
+        }
+      },
+      "device": {
+        "title": "Select Device",
+        "description": "Select your FoxESS device. The device type is shown after the serial number.",
+        "data": {
+          "deviceSN": "Device",
+          "name": "Name"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate FoxESS",
+        "description": "Your FoxESS API key for device {device_sn} is no longer valid. Enter a new API key.",
+        "data": {
+          "apiKey": "API Key"
+        }
+      }
+    },
+    "error": {
+      "already_configured": "Device is already configured",
+      "cannot_connect": "Unable to connect to FoxESS Cloud",
+      "invalid_auth": "Invalid API key",
+      "no_devices": "No devices found in your FoxESS account"
+    },
+    "abort": {
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Re-authentication was successful"
+    }
+  }
+}

--- a/custom_components/foxess/strings.json
+++ b/custom_components/foxess/strings.json
@@ -33,7 +33,9 @@
       "cannot_connect": "Unable to connect to FoxESS Cloud",
       "invalid_auth": "Invalid API key",
       "name_already_in_use": "A device with this name is already configured",
-      "no_devices": "No devices found in your FoxESS account"
+      "no_devices": "No devices found in your FoxESS account",
+      "yaml_device_already_configured": "This device is already configured in configuration.yaml. Remove it from YAML first.",
+      "yaml_name_already_in_use": "A device in configuration.yaml already uses this name."
     },
     "abort": {
       "already_configured": "Device is already configured",

--- a/custom_components/foxess/strings.json
+++ b/custom_components/foxess/strings.json
@@ -13,7 +13,11 @@
         "description": "Select your FoxESS device. The device type is shown after the serial number.",
         "data": {
           "deviceSN": "Device",
-          "name": "Name"
+          "name": "Name",
+          "extendPV": "Extended PV strings (PV7–18)"
+        },
+        "data_description": {
+          "extendPV": "Enable for Fox R series inverters or any inverter with more than 6 PV strings. Reads voltage, current, and power for PV strings 7–18."
         }
       },
       "reauth_confirm": {

--- a/custom_components/foxess/strings.json
+++ b/custom_components/foxess/strings.json
@@ -32,6 +32,7 @@
       "already_configured": "Device is already configured",
       "cannot_connect": "Unable to connect to FoxESS Cloud",
       "invalid_auth": "Invalid API key",
+      "name_already_in_use": "A device with this name is already configured",
       "no_devices": "No devices found in your FoxESS account"
     },
     "abort": {

--- a/custom_components/foxess/translations/en.json
+++ b/custom_components/foxess/translations/en.json
@@ -1,0 +1,38 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "FoxESS Cloud",
+        "description": "Enter your FoxESS OpenAPI key to fetch your devices",
+        "data": {
+          "apiKey": "API Key"
+        }
+      },
+      "device": {
+        "title": "Select Device",
+        "description": "Select your FoxESS device. The device type is shown after the serial number.",
+        "data": {
+          "deviceSN": "Device",
+          "name": "Name"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate FoxESS",
+        "description": "Your FoxESS API key for device {device_sn} is no longer valid. Enter a new API key.",
+        "data": {
+          "apiKey": "API Key"
+        }
+      }
+    },
+    "error": {
+      "already_configured": "Device is already configured",
+      "cannot_connect": "Unable to connect to FoxESS Cloud",
+      "invalid_auth": "Invalid API key",
+      "no_devices": "No devices found in your FoxESS account"
+    },
+    "abort": {
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Re-authentication was successful"
+    }
+  }
+}

--- a/custom_components/foxess/translations/en.json
+++ b/custom_components/foxess/translations/en.json
@@ -33,7 +33,9 @@
       "cannot_connect": "Unable to connect to FoxESS Cloud",
       "invalid_auth": "Invalid API key",
       "name_already_in_use": "A device with this name is already configured",
-      "no_devices": "No devices found in your FoxESS account"
+      "no_devices": "No devices found in your FoxESS account",
+      "yaml_device_already_configured": "This device is already configured in configuration.yaml. Remove it from YAML first.",
+      "yaml_name_already_in_use": "A device in configuration.yaml already uses this name."
     },
     "abort": {
       "already_configured": "Device is already configured",

--- a/custom_components/foxess/translations/en.json
+++ b/custom_components/foxess/translations/en.json
@@ -13,7 +13,11 @@
         "description": "Select your FoxESS device. The device type is shown after the serial number.",
         "data": {
           "deviceSN": "Device",
-          "name": "Name"
+          "name": "Name",
+          "extendPV": "Extended PV strings (PV7–18)"
+        },
+        "data_description": {
+          "extendPV": "Enable for Fox R series inverters or any inverter with more than 6 PV strings. Reads voltage, current, and power for PV strings 7–18."
         }
       },
       "reauth_confirm": {

--- a/custom_components/foxess/translations/en.json
+++ b/custom_components/foxess/translations/en.json
@@ -32,6 +32,7 @@
       "already_configured": "Device is already configured",
       "cannot_connect": "Unable to connect to FoxESS Cloud",
       "invalid_auth": "Invalid API key",
+      "name_already_in_use": "A device with this name is already configured",
       "no_devices": "No devices found in your FoxESS account"
     },
     "abort": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["."]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-homeassistant-custom-component
+xmltodict

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for foxess-ha."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for foxess-ha."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,15 @@
 """FoxESS tests configuration."""
 
 from collections.abc import Generator
-import sys
 from pathlib import Path
+import sys
 from unittest.mock import AsyncMock, patch
-
-# Make `custom_components` importable when pytest runs from the repo root.
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 import pytest
 
 from homeassistant.core import HomeAssistant
 
-pytest_plugins = ["tests.conftest"]
+sys.path.insert(0, str(Path(__file__).parent))
 
 DOMAIN = "foxess"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""FoxESS tests configuration."""
+
+from collections.abc import Generator
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+# Make `custom_components` importable when pytest runs from the repo root.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+pytest_plugins = ["tests.conftest"]
+
+DOMAIN = "foxess"
+
+MOCK_CONFIG = {
+    "name": "FoxESS",
+    "apiKey": "test-api-key",
+    "deviceSN": "ABC123456789",
+    "deviceID": "ABC123456789",
+}
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "custom_components.foxess.async_setup_entry",
+        return_value=True,
+    ) as mock:
+        yield mock

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,439 @@
+"""Tests for the FoxESS config flow."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiohttp import ClientError
+from conftest import DOMAIN, MOCK_CONFIG
+from custom_components.foxess.config_flow import _fetch_device_list
+import pytest
+
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from tests.common import MockConfigEntry
+
+MOCK_DEVICES = [
+    {
+        "deviceSN": "FAKE_DEVICE_SN",
+        "deviceType": "H3-Pro-3G",
+        "productType": "H3",
+        "status": 1,
+    }
+]
+
+STEP1_INPUT = {"apiKey": "test-api-key"}
+
+STEP2_INPUT = {
+    "deviceSN": "FAKE_DEVICE_SN",
+    CONF_NAME: "My Inverter",
+}
+
+
+def _patch_fetch_device_list(return_value: tuple) -> object:
+    return patch(
+        "custom_components.foxess.config_flow._fetch_device_list",
+        return_value=return_value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — API key entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_show_form_step1(hass: HomeAssistant) -> None:
+    """Step 1 form is shown on initial load."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert not result["errors"]
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_step1_invalid_auth(hass: HomeAssistant) -> None:
+    """An invalid API key re-shows step 1 with invalid_auth error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with _patch_fetch_device_list(([], "invalid_auth")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_step1_cannot_connect(hass: HomeAssistant) -> None:
+    """A connection failure re-shows step 1 with cannot_connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with _patch_fetch_device_list(([], "cannot_connect")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_step1_no_devices(hass: HomeAssistant) -> None:
+    """An empty device list re-shows step 1 with no_devices error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with _patch_fetch_device_list(([], "no_devices")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "no_devices"}
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — device selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_step2_shown_after_valid_api_key(hass: HomeAssistant) -> None:
+    """After a valid API key, step 2 (device selector) is shown."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "device"
+    assert not result["errors"]
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_create_entry(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Full happy path through both steps creates a config entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP2_INPUT
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == STEP2_INPUT["deviceSN"]
+    assert result["data"] == {
+        "apiKey": STEP1_INPUT["apiKey"],
+        "deviceSN": STEP2_INPUT["deviceSN"],
+        "deviceID": STEP2_INPUT["deviceSN"],
+        CONF_NAME: STEP2_INPUT[CONF_NAME],
+    }
+    assert result["result"].unique_id == STEP2_INPUT["deviceSN"]
+    mock_setup_entry.assert_called_once()
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_create_entry_default_name(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Omitting the name field uses the default 'FoxESS'."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+
+    step2_no_name = {"deviceSN": STEP2_INPUT["deviceSN"]}
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], step2_no_name
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_NAME] == "FoxESS"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_device_id_set_to_device_sn(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """The deviceID is automatically set equal to deviceSN in the config entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP2_INPUT
+    )
+    await hass.async_block_till_done()
+
+    assert result["data"]["deviceID"] == result["data"]["deviceSN"]
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_duplicate_device_aborts(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Configuring the same deviceSN a second time aborts with already_configured."""
+    # First successful setup
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP2_INPUT
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # Second attempt with same device
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP2_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_device_list unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_session(*, status: int = 200, json_return_value: object = None) -> MagicMock:
+    """Return a mock aiohttp session whose response returns the given status and JSON."""
+    mock_resp = MagicMock()
+    mock_resp.status = status
+    mock_resp.json = AsyncMock(return_value=json_return_value)
+    mock_session = MagicMock()
+    mock_session.post = AsyncMock(return_value=mock_resp)
+    return mock_session
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_fetch_device_list_success(hass: HomeAssistant) -> None:
+    """Errno 0 with a non-empty device list returns (devices, None)."""
+    response = {
+        "errno": 0,
+        "result": {"data": MOCK_DEVICES},
+    }
+    with patch(
+        "custom_components.foxess.config_flow.async_get_clientsession",
+        return_value=_make_mock_session(json_return_value=response),
+    ):
+        devices, error = await _fetch_device_list(hass, "valid-key")
+
+    assert error is None
+    assert devices == MOCK_DEVICES
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_fetch_device_list_invalid_auth_401(hass: HomeAssistant) -> None:
+    """An HTTP 401 response maps to invalid_auth."""
+    with patch(
+        "custom_components.foxess.config_flow.async_get_clientsession",
+        return_value=_make_mock_session(status=401),
+    ):
+        devices, error = await _fetch_device_list(hass, "bad-key")
+
+    assert error == "invalid_auth"
+    assert devices == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_fetch_device_list_unknown_errno(hass: HomeAssistant) -> None:
+    """An unrecognised errno falls back to cannot_connect."""
+    with patch(
+        "custom_components.foxess.config_flow.async_get_clientsession",
+        return_value=_make_mock_session(json_return_value={"errno": 99999}),
+    ):
+        devices, error = await _fetch_device_list(hass, "any-key")
+
+    assert error == "cannot_connect"
+    assert devices == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_fetch_device_list_empty_data(hass: HomeAssistant) -> None:
+    """A successful response with an empty device list returns no_devices."""
+    response = {"errno": 0, "result": {"data": []}}
+    with patch(
+        "custom_components.foxess.config_flow.async_get_clientsession",
+        return_value=_make_mock_session(json_return_value=response),
+    ):
+        devices, error = await _fetch_device_list(hass, "any-key")
+
+    assert error == "no_devices"
+    assert devices == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_fetch_device_list_client_error(hass: HomeAssistant) -> None:
+    """A ClientError maps to cannot_connect."""
+    mock_session = MagicMock()
+    mock_session.post = AsyncMock(side_effect=ClientError())
+    with patch(
+        "custom_components.foxess.config_flow.async_get_clientsession",
+        return_value=mock_session,
+    ):
+        devices, error = await _fetch_device_list(hass, "any-key")
+
+    assert error == "cannot_connect"
+    assert devices == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_fetch_device_list_non_dict_response(hass: HomeAssistant) -> None:
+    """A non-dict JSON body maps to cannot_connect."""
+    with patch(
+        "custom_components.foxess.config_flow.async_get_clientsession",
+        return_value=_make_mock_session(json_return_value=None),
+    ):
+        devices, error = await _fetch_device_list(hass, "any-key")
+
+    assert error == "cannot_connect"
+    assert devices == []
+
+
+# ---------------------------------------------------------------------------
+# Reauth tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_reauth_form_shown(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """The reauth_confirm form is shown when reauth is initiated."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_CONFIG["deviceSN"], data=MOCK_CONFIG)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_reauth_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """A valid new API key updates the entry and reloads."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_CONFIG["deviceSN"], data=MOCK_CONFIG)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"apiKey": "new-valid-api-key"}
+        )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data["apiKey"] == "new-valid-api-key"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations", "mock_setup_entry")
+async def test_reauth_success_no_devices(hass: HomeAssistant) -> None:
+    """A valid key that returns no devices still succeeds reauth."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_CONFIG["deviceSN"], data=MOCK_CONFIG)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with _patch_fetch_device_list(([], "no_devices")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"apiKey": "new-valid-api-key"}
+        )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data["apiKey"] == "new-valid-api-key"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_reauth_invalid_key(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """An invalid API key re-shows the reauth form with an error."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_CONFIG["deviceSN"], data=MOCK_CONFIG)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with _patch_fetch_device_list(([], "invalid_auth")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"apiKey": "bad-api-key"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_reauth_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """A connection error re-shows the reauth form so the user can retry."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=MOCK_CONFIG["deviceSN"], data=MOCK_CONFIG)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with _patch_fetch_device_list(([], "cannot_connect")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"apiKey": "any-api-key"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "cannot_connect"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,12 +6,12 @@ from aiohttp import ClientError
 from conftest import DOMAIN, MOCK_CONFIG
 from custom_components.foxess.config_flow import _fetch_device_list
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from tests.common import MockConfigEntry
 
 MOCK_DEVICES = [
     {
@@ -153,6 +153,7 @@ async def test_create_entry(
         "deviceSN": STEP2_INPUT["deviceSN"],
         "deviceID": STEP2_INPUT["deviceSN"],
         CONF_NAME: STEP2_INPUT[CONF_NAME],
+        "extendPV": False,
     }
     assert result["result"].unique_id == STEP2_INPUT["deviceSN"]
     mock_setup_entry.assert_called_once()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from aiohttp import ClientError
 from conftest import DOMAIN, MOCK_CONFIG
 from custom_components.foxess.config_flow import CONF_DEVICESN, _fetch_device_list
+from custom_components.foxess.sensor import YAML_CONFIGS_KEY
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -277,6 +278,63 @@ async def test_duplicate_name_rejected(
     assert result["errors"] == {CONF_NAME: "name_already_in_use"}
     assert _get_suggested(result, CONF_DEVICESN) == duplicate_input["deviceSN"]
     assert _get_suggested(result, CONF_NAME) == duplicate_input[CONF_NAME]
+
+
+# ---------------------------------------------------------------------------
+# YAML conflict detection tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_yaml_device_sn_blocks_config_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """A deviceSN already configured via YAML shows already_configured error."""
+    hass.data[YAML_CONFIGS_KEY] = {
+        "FAKE_DEVICE_SN": {"deviceID": "some-uuid", "name": "Other Name"},
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"deviceSN": "FAKE_DEVICE_SN", CONF_NAME: "My Name"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "device"
+    assert result["errors"] == {CONF_DEVICESN: "yaml_device_already_configured"}
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_yaml_name_blocks_config_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """A name already used by a YAML-configured device shows yaml_name_already_in_use."""
+    hass.data[YAML_CONFIGS_KEY] = {
+        "OTHER_DEVICE_SN": {"deviceID": "some-uuid", "name": "Taken Name"},
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"deviceSN": "FAKE_DEVICE_SN", CONF_NAME: "Taken Name"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "device"
+    assert result["errors"] == {CONF_NAME: "yaml_name_already_in_use"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import ClientError
 from conftest import DOMAIN, MOCK_CONFIG
-from custom_components.foxess.config_flow import CONF_DEVICE_SN, _fetch_device_list
+from custom_components.foxess.config_flow import CONF_DEVICESN, _fetch_device_list
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -234,8 +234,8 @@ async def test_duplicate_device_shows_error(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "device"
-    assert result["errors"] == {CONF_DEVICE_SN: "already_configured"}
-    assert _get_suggested(result, CONF_DEVICE_SN) == duplicate_input["deviceSN"]
+    assert result["errors"] == {CONF_DEVICESN: "already_configured"}
+    assert _get_suggested(result, CONF_DEVICESN) == duplicate_input["deviceSN"]
     assert _get_suggested(result, CONF_NAME) == duplicate_input[CONF_NAME]
 
 
@@ -275,7 +275,7 @@ async def test_duplicate_name_rejected(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "device"
     assert result["errors"] == {CONF_NAME: "name_already_in_use"}
-    assert _get_suggested(result, CONF_DEVICE_SN) == duplicate_input["deviceSN"]
+    assert _get_suggested(result, CONF_DEVICESN) == duplicate_input["deviceSN"]
     assert _get_suggested(result, CONF_NAME) == duplicate_input[CONF_NAME]
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import ClientError
 from conftest import DOMAIN, MOCK_CONFIG
-from custom_components.foxess.config_flow import _fetch_device_list
+from custom_components.foxess.config_flow import CONF_DEVICE_SN, _fetch_device_list
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -21,6 +21,11 @@ MOCK_DEVICES = [
     }
 ]
 
+MOCK_TWO_DEVICES = [
+    *MOCK_DEVICES,
+    {"deviceSN": "SECOND_DEVICE_SN", "deviceType": "H1-5.0-E", "status": 1},
+]
+
 STEP1_INPUT = {"apiKey": "test-api-key"}
 
 STEP2_INPUT = {
@@ -34,6 +39,14 @@ def _patch_fetch_device_list(return_value: tuple) -> object:
         "custom_components.foxess.config_flow._fetch_device_list",
         return_value=return_value,
     )
+
+
+def _get_suggested(result: dict, key: str) -> object:
+    """Return the suggested_value for a schema field from a form result."""
+    for k in result["data_schema"].schema:
+        if k == key and hasattr(k, "description") and k.description:
+            return k.description.get("suggested_value")
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -68,6 +81,7 @@ async def test_step1_invalid_auth(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "invalid_auth"}
+    assert _get_suggested(result, "apiKey") == STEP1_INPUT["apiKey"]
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -85,6 +99,7 @@ async def test_step1_cannot_connect(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
+    assert _get_suggested(result, "apiKey") == STEP1_INPUT["apiKey"]
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -102,6 +117,7 @@ async def test_step1_no_devices(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "no_devices"}
+    assert _get_suggested(result, "apiKey") == STEP1_INPUT["apiKey"]
 
 
 # ---------------------------------------------------------------------------
@@ -182,34 +198,13 @@ async def test_create_entry_default_name(
     assert result["data"][CONF_NAME] == "FoxESS"
 
 
-@pytest.mark.usefixtures("enable_custom_integrations")
-async def test_device_id_set_to_device_sn(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock
-) -> None:
-    """The deviceID is automatically set equal to deviceSN in the config entry."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    with _patch_fetch_device_list((MOCK_DEVICES, None)):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], STEP1_INPUT
-        )
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], STEP2_INPUT
-    )
-    await hass.async_block_till_done()
-
-    assert result["data"]["deviceID"] == result["data"]["deviceSN"]
-
 
 @pytest.mark.usefixtures("enable_custom_integrations")
-async def test_duplicate_device_aborts(
+async def test_duplicate_device_shows_error(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Configuring the same deviceSN a second time aborts with already_configured."""
+    """Configuring the same deviceSN a second time re-shows step 2 with already_configured."""
     # First successful setup
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -224,29 +219,24 @@ async def test_duplicate_device_aborts(
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
-    # Second attempt with same device
+    # Second attempt: two devices in list, select the already-configured first device with a new name
+    duplicate_input = {"deviceSN": "FAKE_DEVICE_SN", CONF_NAME: "Other Name"}
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+    with _patch_fetch_device_list((MOCK_TWO_DEVICES, None)):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], STEP1_INPUT
         )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], STEP2_INPUT
+        result["flow_id"], duplicate_input
     )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-
-MOCK_DEVICES_2 = [
-    {
-        "deviceSN": "SECOND_DEVICE_SN",
-        "deviceType": "H1-5.0-E",
-        "status": 1,
-    }
-]
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "device"
+    assert result["errors"] == {CONF_DEVICE_SN: "already_configured"}
+    assert _get_suggested(result, CONF_DEVICE_SN) == duplicate_input["deviceSN"]
+    assert _get_suggested(result, CONF_NAME) == duplicate_input[CONF_NAME]
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
@@ -269,22 +259,24 @@ async def test_duplicate_name_rejected(
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
-    # Second attempt with a different device but the same name
+    # Second attempt: two devices in list, select the SECOND device (not default) with the same name
+    duplicate_input = {"deviceSN": "SECOND_DEVICE_SN", CONF_NAME: STEP2_INPUT[CONF_NAME]}
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    with _patch_fetch_device_list((MOCK_DEVICES_2, None)):
+    with _patch_fetch_device_list((MOCK_TWO_DEVICES, None)):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], STEP1_INPUT
         )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {"deviceSN": "SECOND_DEVICE_SN", CONF_NAME: STEP2_INPUT[CONF_NAME]},
+        result["flow_id"], duplicate_input
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "device"
     assert result["errors"] == {CONF_NAME: "name_already_in_use"}
+    assert _get_suggested(result, CONF_DEVICE_SN) == duplicate_input["deviceSN"]
+    assert _get_suggested(result, CONF_NAME) == duplicate_input[CONF_NAME]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,8 +16,7 @@ from homeassistant.data_entry_flow import FlowResultType
 MOCK_DEVICES = [
     {
         "deviceSN": "FAKE_DEVICE_SN",
-        "deviceType": "H3-Pro-3G",
-        "productType": "H3",
+        "deviceType": "H1-5.0-E",
         "status": 1,
     }
 ]
@@ -239,6 +238,53 @@ async def test_duplicate_device_aborts(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+MOCK_DEVICES_2 = [
+    {
+        "deviceSN": "SECOND_DEVICE_SN",
+        "deviceType": "H1-5.0-E",
+        "status": 1,
+    }
+]
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_duplicate_name_rejected(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Configuring a second device with the same name re-shows step 2 with an error."""
+    # First successful setup using the default name
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    with _patch_fetch_device_list((MOCK_DEVICES, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], STEP2_INPUT
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    # Second attempt with a different device but the same name
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    with _patch_fetch_device_list((MOCK_DEVICES_2, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], STEP1_INPUT
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"deviceSN": "SECOND_DEVICE_SN", CONF_NAME: STEP2_INPUT[CONF_NAME]},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "device"
+    assert result["errors"] == {CONF_NAME: "name_already_in_use"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This adds a 2 page configuration UI for inverters, where the first page asks for the API key and uses that to fetch the list of devices which can then be selected on the second page. It doesn't remove YAML configuration which should continue to work as before.

I've also added extensive tests for the UI as well as adding automatic testing for pushes and pull requests on github.

Full disclosure: I'm using this project as an excuse to learn Claude Code, which generated nearly all of this. I've reviewed the code myself and tested it locally, but only have one inverter so can't test every feature in production.