### PR TITLE
Redact API key in debug log

### DIFF
--- a/custom_components/foxess/sensor.py
+++ b/custom_components/foxess/sensor.py
@@ -122,7 +122,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     RestrictGetVar = config.get(CONF_GET_VARIABLES)
     V1_Api = config.get(CONF_V1_API)
     Evo = config.get(CONF_EVO)
-    _LOGGER.debug("API Key: %s", apiKey)
+    _LOGGER.debug("API Key: %s", f"...{apiKey[-4:]}" if apiKey else "(unset)")
     _LOGGER.debug("Device SN: %s", devicesn)
     _LOGGER.debug("Device ID: %s", deviceID)
     _LOGGER.debug("FoxESS Scan Interval: %s minutes", SCAN_MINUTES)


### PR DESCRIPTION
`sensor.py` logs the raw FoxESS OpenAPI key in plaintext at debug level:

_LOGGER.debug("API Key: %s", apiKey)

Debug logging is exactly what users turn on when troubleshooting, and what

_LOGGER.debug("API Key: %s", apiKey)

Debug logging is exactly what users turn on when troubleshooting, and what maintainers ask for in issue reports, so the key gets written to `home-assistant.log` in the clear and then routinely pasted into GitHub issues and forum threads.

This keeps the diagnostic value of the line (confirming a key is loaded, and which one) without writing the secret to disk:

_LOGGER.debug("API Key: %s", f"...{apiKey[-4:]}" if apiKey else "(unset)")

The neighbouring Device SN / Device ID debug lines are left as-is, those aren't credentials.\